### PR TITLE
Add Science from AI section with example topic

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html>
+  <head>
+    <meta charset="utf-8">
+    <title>arivero.github.io</title>
+  </head>
   <body>
-    Not sure if this actually works, it should, according <a href="pages.github.com">pages</a>
+    <h1>arivero.github.io</h1>
+    <p>Not sure if this actually works, it should, according <a href="pages.github.com">pages</a></p>
+
+    <h2>Sections</h2>
+    <ul>
+      <li><a href="science-from-ai/index.html">Science from AI</a> – runs of theoretical science research performed by an AI.</li>
+    </ul>
   </body>
 </html>

--- a/science-from-ai/example-topic/blog.html
+++ b/science-from-ai/example-topic/blog.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Example Topic - Blog</title>
+  </head>
+  <body>
+    <h1>Example Topic – Blog</h1>
+    <p>Informal updates and explanations of the ongoing research will be posted here for a broader audience.</p>
+  </body>
+</html>

--- a/science-from-ai/example-topic/daily-run.html
+++ b/science-from-ai/example-topic/daily-run.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Example Topic - Daily Run</title>
+  </head>
+  <body>
+    <h1>Example Topic – Daily Run</h1>
+    <p>This log tracks daily progress across up to three active subtopics. Each day the AI advances research on the subtopics, dropping unproductive ones and selecting new ones as needed.</p>
+    <!-- Daily entries will be appended below -->
+  </body>
+</html>

--- a/science-from-ai/example-topic/index.html
+++ b/science-from-ai/example-topic/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Example Topic</title>
+  </head>
+  <body>
+    <h1>Example Topic</h1>
+    <ul>
+      <li><a href="daily-run.html">Daily run</a></li>
+      <li><a href="results.html">Results</a></li>
+      <li><a href="blog.html">Blog</a></li>
+    </ul>
+  </body>
+</html>

--- a/science-from-ai/example-topic/results.html
+++ b/science-from-ai/example-topic/results.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Example Topic - Results</title>
+  </head>
+  <body>
+    <h1>Example Topic – Results</h1>
+    <p>Versioned articles summarizing the findings of this research run will be collected here.</p>
+  </body>
+</html>

--- a/science-from-ai/index.html
+++ b/science-from-ai/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Science from AI</title>
+  </head>
+  <body>
+    <h1>Science from AI</h1>
+    <p>This section collects runs of theoretical science research performed by an AI. Each topic maintains three pages:</p>
+    <ul>
+      <li><strong>Daily run</strong> – an hourly or daily log of work. The AI tracks progress across three subtopics and swaps unproductive ones.</li>
+      <li><strong>Results</strong> – a versioned collection of articles produced from the research.</li>
+      <li><strong>Blog</strong> – lighter, more divulgative explanations of the work.</li>
+    </ul>
+    <p>Current topics:</p>
+    <ul>
+      <li><a href="example-topic/index.html">Example Topic</a></li>
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- introduce "Science from AI" section with overview of daily runs, results, and blog pages
- add example topic scaffold including daily log, results, and blog placeholders
- link new section from main index

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a89d0e4c10832d977e4224b7e08db2